### PR TITLE
Remove cache of episode_released and makes it use get_seriedata instead of urllib call

### DIFF
--- a/epguides.py
+++ b/epguides.py
@@ -1,7 +1,6 @@
 import urllib
 import datetime
 import re
-import json
 
 from beaker.cache import CacheManager
 from beaker.util import parse_cache_config_options
@@ -42,14 +41,12 @@ def get_seriedata(url):
 
     f.close()
 
-    return json.dumps(show)
+    return show
 
 
 def episode_released(show_name, season, episode):
     status = False
-    data = json.loads(get_seriedata(show_name))
-
-    episode = int(episode)
+    data = get_seriedata(show_name)
 
     if season in data or len(data[season]) >= episode:
         release_date = datetime.datetime.strptime(data[season][episode - 1][2], "%Y-%m-%d")
@@ -57,4 +54,4 @@ def episode_released(show_name, season, episode):
         if datetime.datetime.now() - datetime.timedelta(hours=32) > release_date:
             status = True
 
-    return json.dumps({'status': status})
+    return status

--- a/view.py
+++ b/view.py
@@ -1,5 +1,7 @@
-from epguides import get_seriedata, episode_released
 import web
+import json
+
+from epguides import get_seriedata, episode_released
 
 urls = (
     '/show/(\w*)/?', 'view.index',
@@ -9,12 +11,14 @@ urls = (
 
 class index:
     def GET(self, show):
-        return get_seriedata(show)
+        return json.dumps(get_seriedata(show))
 
 
 class released:
     def GET(self, show, season, episode):
-        return episode_released(show, season, episode)
+        return json.dumps({
+            'status': episode_released(show, int(season), int(episode))
+        })
 
 if __name__ == "__main__":
     app = web.application(urls, globals())


### PR DESCRIPTION
This will make it uneccessary to invalidate the cache often since epguides serves dates of future episode some weeks before they air. At least in most cases.

Also refactors and move all json handling to the web.py files.
