### PR TITLE
Fixes parsing bug that fails to load all content

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -124,7 +124,7 @@ def parse_epguides_data(url):
 def parse_epguides_info(url):
     try:
         data = requests.get("http://epguides.com/" + url).text
-        return re.findall('<h1><a href="[\w\:\/\/.]*title\/(.*)">(.*)<\/a>',
+        return re.findall('<h2><a href="[\w\:\/\/.]*title\/(.*)">(.*)<\/a>',
                           data)[0]
 
     except IndexError:


### PR DESCRIPTION
Hi! Nice work on the API, it will come in handy for a small project I'm working on. 

It doesn't work, however. Every episode and show fails with "not found". This is because parse_epguides_info looks for an `<h1>` in the epguides.com DOM, but it seems to have been changed to an `<h2>`. This pull request fixes that.

I had trouble running the API locally, so I also upgraded all the packages to the latest version and the interpreter to python3. It seemed to work fine, though a couple of tests failed because of changes in the TVRage API. Let me know if you want to merge this as well.