### PR TITLE
chore(docs): repo hygiene files (closes #195)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,37 @@
+# Epguides API — Cursor IDE rules
+
+REST API + MCP server for TV show metadata. FastAPI + Redis cache.
+Python 3.12+, all I/O async.
+
+## Conventions
+
+- **Python 3.12+** — type hints. `dict[str, X]`, `X | None`.
+- **All I/O async.** httpx.AsyncClient.
+- **`@cached(...)` decorator** for service-layer functions. TTLs
+  defined in `app/core/constants.py` (TTL_7_DAYS / TTL_30_DAYS /
+  TTL_1_YEAR).
+- **Schema factory** — use `create_show_schema(...)` not
+  `ShowSchema(...)` direct.
+- **Async parallel** via `asyncio.gather()`.
+- **Mock patterns** — `@patch("app.core.cache.cache_get",
+  return_value=None)` for cache miss; `@patch(
+  "app.services.show_service.get_show")` for service layer.
+- **Performance**: < 50ms hard limit, < 20ms target.
+- **If code can't be tested, remove it.**
+
+## Coverage
+
+100% test coverage enforced by pre-commit. Commits blocked if coverage
+drops.
+
+## Operational rules
+
+- **Pre-commit must pass** — ruff + 100% coverage. Don't `--no-verify`.
+- **All config in git.** SSH edits on VMID 122 are ephemeral.
+- **Docker only** — `make` targets, never host pip/poetry.
+
+## Where things live
+
+- Architecture, caching pattern, mock patterns: CLAUDE.md
+- TTL constants: `app/core/constants.py`
+- Caching decorator: `app/core/cache.py`

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,29 +1,18 @@
-# EditorConfig is awesome: https://EditorConfig.org
-
 root = true
 
 [*]
-charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+charset = utf-8
 trim_trailing_whitespace = true
 
-[*.py]
+[*.{py,toml,md,sh,j2}]
 indent_style = space
 indent_size = 4
-max_line_length = 120
 
-[*.{yml,yaml}]
+[*.{yaml,yml,json,html,jinja2,ts,tsx,js,jsx,css,scss}]
 indent_style = space
 indent_size = 2
-
-[*.{json,jsonc}]
-indent_style = space
-indent_size = 2
-
-[*.md]
-trim_trailing_whitespace = false
-max_line_length = off
 
 [Makefile]
 indent_style = tab

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner
+* @frecar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to Epguides API
+
+TV show metadata API + MCP server. Production at
+https://epguides.frecar.no (VMID 122 on thor).
+
+## Setup
+
+```bash
+git clone git@github.com:frecar/epguides-api.git
+cd epguides-api
+make setup   # venv + pre-commit hooks
+```
+
+## Daily
+
+```bash
+make up         # docker compose, hot reload
+make down
+make test       # 100% coverage required
+make fix        # ruff format + lint auto-fix
+make doctor     # env health check
+make urls       # show service URLs
+make clean      # remove caches
+```
+
+Single test:
+
+```bash
+pytest app/tests/test_endpoints.py::test_function -v
+```
+
+## Coverage
+
+100% enforced by pre-commit. Commits blocked if coverage drops. If you
+can't test it, remove it.
+
+## Workflow
+
+1. Branch off `main` (`feat/`, `fix/`, `chore/`, `docs/`).
+2. Commit. Pre-commit runs ruff + version bump + 100% coverage tests.
+   Never `--no-verify`.
+3. Push.
+4. PR. Squash merge.
+
+## Deploy
+
+`./pm services deploy --service epguides --vmid 122 --yes` from asgard.
+Auto-update at 04:00 UTC daily.
+
+## Where things live
+
+- Architecture, caching pattern: CLAUDE.md
+- TTL constants: `app/core/constants.py`
+- Adding endpoints: `app/api/endpoints/`


### PR DESCRIPTION
Standard repo hygiene: `.cursorrules` (where missing — preserved any existing), `.editorconfig`, `CONTRIBUTING.md` (where missing — preserved any existing), `.github/CODEOWNERS`. References existing CLAUDE.md — no new conventions, just discoverable from canonical filenames.