### PR TITLE
chore(deps): include transitive deps in dependabot scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "deps"
+    # Include transitive deps so CVEs in indirect packages (like the urllib3
+    # 2.6.3 → 2.7.0 incident in sentinel on 2026-05-11) get auto-PRs. Wave 3
+    # of asgard #683 rollout; sentinel #371 is the canary.
+    allow:
+      - dependency-type: "all"
     groups:
       python-minor:
         patterns:


### PR DESCRIPTION
Wave 3 of asgard #683 cluster rollout. Mirrors sentinel #371 (canary), portal #267, soldprice #244, elfai #502.

Refs sentinel #368, asgard #683