### PR TITLE
feat(security): trivy fs scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,38 @@ jobs:
           REDIS_PORT: 6379
         run: uv run pytest --cov=app --cov-fail-under=100 --cov-report=term-missing -q
 
+  # Trivy fs scan. Standalone job here so PR/push runs gate on it via
+  # ci-gate. The companion .github/workflows/trivy-fs-nightly.yml owns
+  # the 03:30 UTC schedule trigger independently so scheduled sweeps
+  # do not conflate with PR signal.
+  trivy-fs:
+    name: Trivy fs scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          # CRITICAL + HIGH gate PR. Tightens over time as we drain
+          # the allowlist; widen severity if we want lower tiers in
+          # the gate later.
+          severity: "CRITICAL,HIGH"
+          exit-code: "1"
+          # Suppress findings with no upstream fix available — those
+          # are noise we cannot act on (`bump the dep` is the only
+          # real remediation, and there is nothing to bump to).
+          ignore-unfixed: true
+          format: "table"
+          trivyignores: ".trivyignore"
+        env:
+          TRIVY_DISABLE_VEX_NOTICE: "true"
+
   ci-gate:
     if: always()
-    needs: [audit, lint, typecheck, test]
+    needs: [audit, lint, typecheck, test, trivy-fs]
     runs-on: ubuntu-latest
     steps:
       - run: |

--- a/.github/workflows/trivy-fs-nightly.yml
+++ b/.github/workflows/trivy-fs-nightly.yml
@@ -1,0 +1,40 @@
+name: Trivy fs nightly sweep
+# Nightly Trivy fs sweep — catches CVEs published against pinned
+# versions since the last PR. Companion to the `trivy-fs` job in
+# ci.yml (which gates PR/push). Identical scan, different trigger.
+#
+# Runs at 03:30 UTC — findings land in the Actions log and (on
+# failure) surface via GitHub's default workflow-failure
+# notifications without blocking any PR.
+#
+# `ignore-unfixed: true` suppresses upstream-not-yet-patched noise
+# (bumping the dep is the only real remediation, and there is
+# nothing to bump to yet).
+
+on:
+  schedule:
+    - cron: "30 3 * * *"
+  # Manual dispatch for ad-hoc re-scans (e.g. after editing
+  # .trivyignore to verify the allowlist behaves as intended).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trivy-fs-nightly:
+    name: Trivy fs scan (nightly)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          severity: "CRITICAL,HIGH"
+          exit-code: "1"
+          ignore-unfixed: true
+          format: "table"
+          trivyignores: ".trivyignore"
+        env:
+          TRIVY_DISABLE_VEX_NOTICE: "true"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,24 @@
+# Trivy filesystem scan allowlist.
+#
+# Format: one CVE/GHSA per line. Comments via `#`. See
+#   https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/
+#
+# Policy (mirrors `.osv-scanner.toml` CVSS tiers):
+#   Critical (>= 9.0)   ignored max 14 days
+#   High (7.0 - 8.9)    ignored max 30 days
+#   Medium (4.0 - 6.9)  ignored max 90 days
+#
+# When adding an ignore, document it with these inline comments
+# above the line:
+#   # type: <upstream-not-fixed | false-positive | accepted-risk>
+#   # reviewer: <name>
+#   # expires: <YYYY-MM-DD>
+#   # reason: <one-line>
+#   <CVE-ID-or-GHSA-ID>
+#
+# What does NOT belong here: upstream-fixed CVEs (bump the dep
+# instead — `ignore-unfixed: true` in the workflow already filters
+# unfixed findings to suppress the noise class).
+#
+# Empty by default. Land allowlists with the same scrutiny as any
+# code change — no silent bypass.


### PR DESCRIPTION
## Summary

Adds Trivy filesystem scan to CI + nightly schedule. Template matches the per-repo security contract (rolled out across other repos under the parent issue).

## Changes

- `.github/workflows/trivy-fs-nightly.yml` — nightly Trivy fs sweep at 03:30 UTC (catches CVEs published against pinned deps between PRs).
- `.github/workflows/ci.yml` — adds a `trivy-fs` job gating PRs/pushes, and includes it in `ci-gate.needs`.
- `.trivyignore` — empty allowlist with policy comments (CVSS-tier TTLs + required inline metadata format).

## Scan config

- Severity gate: `CRITICAL,HIGH`.
- `ignore-unfixed: true` to suppress upstream-not-yet-patched noise (nothing to bump to).
- No allowlist entries land in this PR — `.trivyignore` is empty by default.

## Test plan

- [ ] PR CI: `trivy-fs` job runs and reports findings (or passes if none).
- [ ] `ci-gate` blocks merge if `trivy-fs` fails.
- [ ] Nightly workflow can be triggered manually via `workflow_dispatch` to confirm parity with the PR job.