### PR TITLE
deps: bump redis 7.4.0 -> 8.0.0 (with typing adaptation)

### DIFF
--- a/app/core/cache.py
+++ b/app/core/cache.py
@@ -112,7 +112,7 @@ async def invalidate_cache(key_prefix: str, key_suffix: str) -> bool:
     try:
         redis = await get_redis()
         cache_key = f"{key_prefix}:{key_suffix}"
-        deleted = cast("int", await redis.delete(cache_key))
+        deleted = await redis.delete(cache_key)
         if deleted:
             logger.info("Invalidated cache: %s", cache_key)
         return bool(deleted > 0)
@@ -136,7 +136,7 @@ async def extend_cache_ttl(key_prefix: str, key_suffix: str, new_ttl: int) -> bo
     try:
         redis = await get_redis()
         cache_key = f"{key_prefix}:{key_suffix}"
-        result = cast("bool", await redis.expire(cache_key, new_ttl))
+        result = await redis.expire(cache_key, new_ttl)
         if result:
             logger.info("Extended cache TTL for %s to %d seconds", cache_key, new_ttl)
         return result
@@ -183,8 +183,9 @@ async def cache_hget(hash_key: str, field: str) -> str | None:
     """Get field from hash, or None on miss/error."""
     try:
         redis = await get_redis()
-        # redis.hget returns Awaitable[str | None] but type stubs are wrong
-        result: str | None = await redis.hget(hash_key, field)  # type: ignore[misc]
+        # decode_responses=True yields str at runtime; the command overloads
+        # still annotate bytes|str|None, so narrow at the Redis boundary.
+        result = cast("str | None", await redis.hget(hash_key, field))
         return result
     except Exception as e:
         logger.warning("Cache hash read error for %s[%s]: %s", hash_key, field, e)
@@ -195,7 +196,7 @@ async def cache_exists(key: str) -> bool:
     """Check if key exists in cache."""
     try:
         redis = await get_redis()
-        count = cast("int", await redis.exists(key))
+        count = await redis.exists(key)
         return bool(count > 0)
     except Exception:
         return False
@@ -366,9 +367,10 @@ async def get_cache_stats() -> dict[str, Any]:
     try:
         redis = await get_redis()
 
-        # Get all keys and categorize them
-        keys: list[bytes] = await redis.keys("*")
-        key_strings = [k.decode() if isinstance(k, bytes) else k for k in keys]
+        # Get all keys and categorize them. decode_responses=True means the
+        # client returns str keys at runtime; the overloads still type these
+        # as list[bytes | str], so narrow at the Redis boundary.
+        key_strings = cast("list[str]", await redis.keys("*"))
 
         # Categorize keys
         shows_cached = sum(1 for k in key_strings if k.startswith("show:") and not k.endswith(":raw"))

--- a/app/tests/test_cache.py
+++ b/app/tests/test_cache.py
@@ -412,13 +412,15 @@ async def test_cached_decorator_without_model():
 async def test_get_cache_stats_returns_stats():
     """Test get_cache_stats returns cache statistics."""
     mock_redis = AsyncMock()
+    # The client is created with decode_responses=True, so KEYS returns
+    # already-decoded str values at runtime — mirror that here.
     mock_redis.keys.return_value = [
-        b"show:test1",
-        b"show:test2",
-        b"episodes:test1",
-        b"seasons:test1",
-        b"shows:all:raw",
-        b"show_index",
+        "show:test1",
+        "show:test2",
+        "episodes:test1",
+        "seasons:test1",
+        "shows:all:raw",
+        "show_index",
     ]
     mock_redis.ttl.return_value = 86400
     mock_redis.info.return_value = {"used_memory_human": "10M", "used_memory_peak_human": "15M"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["tv", "shows", "api", "epguides", "fastapi"]
 dependencies = [
     "fastapi==0.136.3",
     "uvicorn[standard]==0.48.0",
-    "redis==7.4.0",
+    "redis==8.0.0",
     "pydantic==2.13.4",
     "pydantic-settings==2.14.1",
     "python-multipart==0.0.29",

--- a/uv.lock
+++ b/uv.lock
@@ -295,7 +295,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "==2.14.1" },
     { name = "python-dateutil", specifier = "==2.9.0.post0" },
     { name = "python-multipart", specifier = "==0.0.29" },
-    { name = "redis", specifier = "==7.4.0" },
+    { name = "redis", specifier = "==8.0.0" },
     { name = "sentry-sdk", specifier = "==2.61.0" },
     { name = "setuptools", specifier = "==82.0.1" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.48.0" },
@@ -918,11 +918,11 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "7.4.0"
+version = "8.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supersedes #288 (dependabot's bare bump), which went red on `Type Check`.

## Problem

redis-py 8.0.0 systematically applied `@overload` across its commands so
**sync** clients now see concrete return types (`int`, `bool`, `list[str]`)
instead of the old combined `ResponseT` union. Per the release notes this is a
**type-checking-only breaking change — runtime behavior is unchanged.**

The bare bump left mypy failing with 6 errors in `app/core/cache.py`:

- `Redundant cast to "int"` on `cast("int", await redis.delete(...))` and `cast("int", await redis.exists(...))`
- `Redundant cast to "bool"` on `cast("bool", await redis.expire(...))`
- `Unused "type: ignore"` + `Incompatible types (bytes | str | None vs str | None)` on `redis.hget(...)`
- `Incompatible types (list[bytes | str] vs list[bytes])` on `redis.keys("*")`

## Fix

Adapt the annotations to the new, more precise types — **zero new `# type: ignore`**, no runtime change:

- Drop the now-redundant `cast()` on `delete()` / `expire()` / `exists()` — let inference flow from the concrete overloads.
- Narrow `hget()` → `str | None` and `keys()` → `list[str]` at the client boundary. The client is created with `decode_responses=True`, so values are `str` at runtime, but the overloads still annotate `bytes | str` (they can't see `decode_responses` at the type level), so a boundary `cast()` is the correct idiom.
- Remove the now-dead bytes-decode branch in `get_cache_stats()` — with `decode_responses=True`, keys are already `str`.

Also corrects the `get_cache_stats` test mock, which previously returned `bytes`
keys — a shape the client never produces with `decode_responses=True`. The mock
now returns `str` keys, matching the real runtime contract.

## Test plan

- [x] `mypy app/ --config-file pyproject.toml --exclude 'app/tests/'` → `Success: no issues found in 25 source files`
- [x] Full `pytest` suite green with the 100% coverage gate → `609 passed, 6 skipped`
- [x] `ruff check` + `ruff format --check` clean
- [x] No-external-LLM and no-internal-refs guard scripts pass

## Out of scope

- redis-py 8.0 deprecates `setex` in favor of `set(..., ex=...)` (surfaces as a `DeprecationWarning`). Tracked as a follow-up chore; not addressed here to keep this PR a focused, behavior-neutral type adaptation.