### PR TITLE
ci: prove ci runner cutover

### DIFF
--- a/.github/workflows/ci-cutover-proof.yml
+++ b/.github/workflows/ci-cutover-proof.yml
@@ -1,0 +1,19 @@
+name: CI cutover proof
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci-runner-proof:
+    runs-on: [self-hosted, Linux, X64, cluster-ci]
+    timeout-minutes: 5
+    steps:
+      - name: Prove this PR job is on the dedicated ci LXC
+        run: |
+          echo "runner=${{ runner.name }}"
+          echo "hostname=$(hostname)"
+          test "$(hostname)" = ci


### PR DESCRIPTION
Temporary proof PR for frecar/asgard#2284. This exercises real epguides-api CI after the x86_64 CPU pool moved from l40s to the dedicated ci LXC. Do not merge; close after checks are captured.