### PR TITLE
chore: sync no-external-llm hook

### DIFF
--- a/scripts/check_no_external_llm.py
+++ b/scripts/check_no_external_llm.py
@@ -43,6 +43,7 @@ ALLOWED_PATH_COMPONENTS = (
     "node_modules",
     "__pycache__",
     ".git",
+    ".claude",  # local agent tooling worktrees, never part of a checkout's source
     ".next",
     ".cache",
     ".mypy_cache",


### PR DESCRIPTION
## Summary
- sync the checked-in no-external-LLM policy scanner to the current canonical copy
- source revision: `88c8e85e9ced`

## Review
- generated by the canonical hook-sync workflow
- no runtime code changes
