### PR TITLE
chore: sync stream-choices-guard hook

### DIFF
--- a/scripts/check_stream_choices_guard.py
+++ b/scripts/check_stream_choices_guard.py
@@ -244,10 +244,7 @@ def check_file(path: Path) -> list[tuple[int, str]]:
 
 
 def main(argv: list[str]) -> int:
-    if argv:
-        files = [Path(a) for a in argv]
-    else:
-        files = [p for p in Path.cwd().rglob("*.py") if p.is_file()]
+    files = [Path(a) for a in argv] if argv else [p for p in Path.cwd().rglob("*.py") if p.is_file()]
 
     violation_count = 0
     for f in files:


### PR DESCRIPTION
## Summary
- sync the checked-in stream-choices-guard lint script to the current canonical copy
- source revision: `9807ecd766b8`

## Review
- generated by the canonical hook-sync workflow
- no runtime code changes
