### PR TITLE
chore: pin uv to 0.11.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM python:3.14.5-slim AS builder
 # The astral-sh/uv image only contains the static uv binary; we COPY it
 # into our python base image rather than using it as the base (which lacks
 # python).
-COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /usr/local/bin/uv
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary
- pin every `COPY --from=ghcr.io/astral-sh/uv:<v>` Docker stage to the single uv version `0.11.21`
- a uv that predates the pinned Python patch fails the image build with `No interpreter found`; one synced version keeps the image deterministic
- the CI `astral-sh/setup-uv` `version:` is intentionally left floating and is not changed by this PR

## Review
- generated by the uv-pin sync workflow
- no runtime code changes
