### PR TITLE
chore: sync no-external-llm hook

### DIFF
--- a/scripts/check_no_external_llm.py
+++ b/scripts/check_no_external_llm.py
@@ -55,7 +55,6 @@ ALLOWED_PATH_COMPONENTS = (
 )
 ALLOWED_FILENAMES = {
     "check_no_external_llm.py",
-    "benchmark_llm.py",
 }
 # File extensions we DO want to check. Skip binaries, lockfiles, etc.
 CHECKED_EXTENSIONS = {


### PR DESCRIPTION
## Summary
- sync the checked-in no-external-LLM policy scanner to the current canonical copy
- source revision: `47ca520378e5`

## Review
- generated by the canonical hook-sync workflow
- no runtime code changes
