### PR TITLE
chore: pin uv to 0.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM python:3.14.6-slim@sha256:ce40764625a4ff50df3548277632e7f96c4e77fe75fa848aa
 # this line. The astral-sh/uv image only contains the static uv binary; we COPY
 # it into our python base image rather than using it as the base (which lacks
 # python).
-COPY --from=ghcr.io/astral-sh/uv:0.11.21 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.2 /uv /usr/local/bin/uv
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary
- pin every `COPY --from=ghcr.io/astral-sh/uv:<v>` Docker stage to the single uv version `0.12.2`
- a uv that predates the pinned Python patch fails the image build with `No interpreter found`; one synced version keeps the image deterministic
- the CI `astral-sh/setup-uv` `version:` is intentionally left floating and is not changed by this PR

## Review
- generated by the uv-pin sync workflow
- no runtime code changes
